### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-MIX = MIX
+MIX = mix
 .DEFAULT_GOAL	:= all
 
 .PHONY: all compile clean-all clean clobber test check deps rel shell xref dialyzer eunit exunit erl iex
@@ -33,9 +33,6 @@ exunit:
 
 eunit:
 	@$(MIX) eunit --cover
-
-proper:
-	@$(MIX) proper
 
 xref:
 	@$(MIX) xref graph


### PR DESCRIPTION
`MIX` should be bound to `mix`

It's a pet peeve of mine to include targets in Makefiles that do not do
anything, hence the removal of `proper`. Will back this change out if I
am not in similar company.

Signed-off-by: Tom Santero <tom.santero@postmates.com>