### PR TITLE
Fix cerlnan_avro_socket gen_server Exports

### DIFF
--- a/src/cerlnan_avro.app.src
+++ b/src/cerlnan_avro.app.src
@@ -1,6 +1,6 @@
 {application, cerlnan_avro,
  [
-  {description, "Erlang client for cernan's avro source."},
+  {description, "Erlang client for Cernan's avro source."},
   {vsn, "0.0.1"},
   {registered, [cerlnan_avro]},
   {mod, {cerlnan_avro_app, []}},
@@ -15,6 +15,6 @@
   {maintainers, ["Postmates"]},
   {licenses, ["MIT"]},
   {build_tools, ["rebar3"]},
-  {links, [{"Github", "https://github.com/postmates/cerlnan"}]}
+  {links, [{"Github", "https://github.com/postmates/cerlnan_avro"}]}
  ]
 }.

--- a/src/cerlnan_avro_byte_buffer.erl
+++ b/src/cerlnan_avro_byte_buffer.erl
@@ -1,5 +1,5 @@
 -module(cerlnan_avro_byte_buffer).
--behaviour(gen_server).
+-behavior(gen_server).
 
 % An imposter for file descriptor, supporting only writes.
 %
@@ -28,7 +28,7 @@
 %% API
 %%====================================================================
 
--spec open() -> buffer().
+-spec open() -> {ok, buffer()} | ignore | {error, term()}.
 open() ->
     gen_server:start_link(?MODULE, ok, []).
 

--- a/src/cerlnan_avro_socket.erl
+++ b/src/cerlnan_avro_socket.erl
@@ -1,11 +1,13 @@
 -module(cerlnan_avro_socket).
--behaviour(gen_server).
+-behavior(gen_server).
 
 % API
 -export([publish_blob/3]).
 
 % gen_server callbacks
--export([start/1, start_link/1, init/1, handle_call/3, handle_cast/2]).
+-export([start/1, start_link/1, init/1,
+         handle_call/3, handle_cast/2, handle_info/2,
+         code_change/3, terminate/2]).
 
 -define(CERLNAN_AVRO_DEFAULT_BACKEND, cerlnan_avro_socket_v1).
 
@@ -67,6 +69,15 @@ handle_call({publish_blob, Blob, Args}, _From, State=#{backend:=Backend, backend
 
 handle_cast(_, State) ->
     {noreply, State}.
+
+handle_info(_, State) ->
+    {noreply, State}.
+
+code_change(_, _, State) ->
+    {ok, State}.
+
+terminate(_, _State) ->
+    ok.
 
 %%====================================================================
 %% Tests


### PR DESCRIPTION
Previous version missed the missing callbacks as it used `-behaviour`.
`-behavior` caught the error, which is surprising.