### PR TITLE
Propagate Errors to Users + Fix Sync Semantics

### DIFF
--- a/src/cerlnan_avro.erl
+++ b/src/cerlnan_avro.erl
@@ -302,7 +302,10 @@ cerlnan_avro_timeout_test_() ->
             application:stop(cerlnan_avro),
             erlang:exit(ServerPid, normal)
         end,
-        [fun() -> {error, timeout} = publish_basic() end,
+        [fun() ->
+            {error, timeout} = publish_basic(),
+            timer:sleep(1) %% Pause let the worker restart.
+         end,
          fun() -> ok = publish_basic(false) end
         ]
     }.


### PR DESCRIPTION
Users are now made aware when publications fail, improving
observability.  Pool workers still crash on error after returning the
result up to the user.

Once errors were propogated, a bug was discovered in
which sync publishes were still being treated as async.  This has been
corrected and a new unit test added.