### PR TITLE
Fix application dependencies

### DIFF
--- a/src/cerlnan_avro.app.src
+++ b/src/cerlnan_avro.app.src
@@ -8,7 +8,9 @@
    [
     kernel,
     stdlib,
-    lager
+    lager,
+    erlavro,
+    poolboy
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
This is necessary for reltool and distillery to correctly find that erlavro and poolboy are needed at runtime.